### PR TITLE
feat: builder configurator & custom client

### DIFF
--- a/src/Transmitly.Microsoft.Extensions.DependencyInjection/ICommunicationsClientConfigurator.cs
+++ b/src/Transmitly.Microsoft.Extensions.DependencyInjection/ICommunicationsClientConfigurator.cs
@@ -1,0 +1,23 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Transmitly;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	public interface ICommunicationsClientConfigurator
+	{
+		void ConfigureClient(CommunicationsClientBuilder builder);
+	}
+}

--- a/src/Transmitly.Microsoft.Extensions.DependencyInjection/ServiceCollectionCommunicationClient.cs
+++ b/src/Transmitly.Microsoft.Extensions.DependencyInjection/ServiceCollectionCommunicationClient.cs
@@ -1,0 +1,60 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Transmitly;
+using Transmitly.Delivery;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	class ServiceCollectionCommunicationClient(ICommunicationsClientConfigurator configurator) : ICommunicationsClient
+	{
+		private readonly Lazy<ICommunicationsClient> _lazy = new(() =>
+		{
+			var builder = new CommunicationsClientBuilder();
+			configurator.ConfigureClient(builder);
+			return builder.BuildClient();
+		});
+
+		private ICommunicationsClient Client
+		{
+			get
+			{
+				return _lazy.Value;
+			}
+		}
+		public void DeliverReport(DeliveryReport report)
+		{
+			Client.DeliverReport(report);
+		}
+
+		public void DeliverReports(IReadOnlyCollection<DeliveryReport> reports)
+		{
+			Client.DeliverReports(reports);
+		}
+
+		public Task<IDispatchCommunicationResult> DispatchAsync(string pipelineName, IReadOnlyCollection<IPlatformIdentityProfile> platformIdentities, ITransactionModel transactionalModel, IReadOnlyCollection<string> channelPreferences, string? cultureInfo = null, CancellationToken cancellationToken = default)
+		{
+			return Client.DispatchAsync(pipelineName, platformIdentities, transactionalModel, channelPreferences, cultureInfo, cancellationToken);
+		}
+
+		public Task<IDispatchCommunicationResult> DispatchAsync(string pipelineName, IReadOnlyCollection<IPlatformIdentityReference> identityReferences, ITransactionModel transactionalModel, IReadOnlyCollection<string> channelPreferences, string? cultureInfo = null, CancellationToken cancellationToken = default)
+		{
+			return Client.DispatchAsync(pipelineName, identityReferences, transactionalModel, channelPreferences, cultureInfo, cancellationToken);
+		}
+	}
+}

--- a/src/Transmitly.Microsoft.Extensions.DependencyInjection/ServiceCollectionCommunicationClientFactory.cs
+++ b/src/Transmitly.Microsoft.Extensions.DependencyInjection/ServiceCollectionCommunicationClientFactory.cs
@@ -75,9 +75,9 @@ namespace Transmitly.Microsoft.Extensions.DependencyInjection
 			_services.AddSingleton<ITemplateEngineFactory, DefaultTemplateEngineFactory>();
 			_services.AddSingleton<IPipelineFactory, DefaultPipelineFactory>();
 			_services.AddSingleton<IChannelProviderFactory, ServiceProviderChannelProviderFactory>();
-			_services.AddSingleton<ICommunicationsClient, DefaultCommunicationsClient>();
 			_services.AddSingleton<IPersonaFactory, DefaultPersonaFactory>();
 			_services.AddSingleton<IPlatformIdentityResolverFactory, ServiceProviderPlatformIdentityResolverRegistrationFactory>();
+			_services.AddSingleton<ICommunicationsClient, DefaultCommunicationsClient>();
 
 			return new EmptyClient();
 		}

--- a/src/Transmitly.Microsoft.Extensions.DependencyInjection/TransmitlyDependencyInjectionExtensions.cs
+++ b/src/Transmitly.Microsoft.Extensions.DependencyInjection/TransmitlyDependencyInjectionExtensions.cs
@@ -12,6 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using Transmitly;
 using Transmitly.Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,40 @@ namespace Microsoft.Extensions.DependencyInjection
 {
 	public static class TransmitlyDependencyInjectionExtensions
 	{
+		public static IServiceCollection AddTransmitly(this IServiceCollection services, Type configuratorType)
+		{
+			ValidateImplementsInterface(configuratorType, typeof(ICommunicationsClientConfigurator));
+
+			services.TryAddSingleton(typeof(ICommunicationsClientConfigurator), configuratorType);
+			services.AddSingleton<ICommunicationsClient, ServiceCollectionCommunicationClient>();
+			return services;
+		}
+
+		public static IServiceCollection AddTransmitly<TConfigurator>(this IServiceCollection services)
+			where TConfigurator : class, ICommunicationsClientConfigurator
+		{
+			return AddTransmitly(services, typeof(TConfigurator));
+		}
+
+		public static IServiceCollection AddTransmitly<TConfigurator, TClient>(this IServiceCollection services, Type configuratorType, Type clientType)
+		{
+			Guard.AgainstNull(services);
+
+			ValidateImplementsInterface(configuratorType, typeof(ICommunicationsClientConfigurator));
+			ValidateImplementsInterface(clientType, typeof(ICommunicationsClient));
+
+			services.TryAddSingleton(typeof(ICommunicationsClientConfigurator), configuratorType);
+			services.AddSingleton(typeof(ICommunicationsClient), clientType);
+			return services;
+		}
+
+		public static IServiceCollection AddTransmitly<TConfigurator, TClient>(this IServiceCollection services)
+			where TConfigurator : class, ICommunicationsClientConfigurator
+			where TClient : class, ICommunicationsClient
+		{
+			return AddTransmitly<TConfigurator, TClient>(services, typeof(TConfigurator), typeof(TClient));
+		}
+
 		public static IServiceCollection AddTransmitly(this IServiceCollection services, Action<CommunicationsClientBuilder> options)
 		{
 			Guard.AgainstNull(options);
@@ -30,6 +65,15 @@ namespace Microsoft.Extensions.DependencyInjection
 			builder.RegisterClientFactory(new ServiceCollectionCommunicationClientFactory(services));
 			builder.BuildClient();
 			return services;
+		}
+
+		private static void ValidateImplementsInterface(Type type, Type interfaceType)
+		{
+			Guard.AgainstNull(type);
+			Guard.AgainstNull(interfaceType);
+
+			if (!interfaceType.IsAssignableFrom(type))
+				throw new InvalidOperationException($"Type {type.FullName} must implement {interfaceType.FullName}");
 		}
 	}
 }

--- a/src/Transmitly.Microsoft.Extensions.DependencyInjection/TransmitlyDependencyInjectionExtensions.cs
+++ b/src/Transmitly.Microsoft.Extensions.DependencyInjection/TransmitlyDependencyInjectionExtensions.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Extensions.DependencyInjection
 	{
 		public static IServiceCollection AddTransmitly(this IServiceCollection services, Action<CommunicationsClientBuilder> options)
 		{
+			Guard.AgainstNull(options);
+			Guard.AgainstNull(services);
+
 			var builder = new CommunicationsClientBuilder();
 			options(builder);
 			builder.RegisterClientFactory(new ServiceCollectionCommunicationClientFactory(services));

--- a/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/ConfigureClientTracker.cs
+++ b/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/ConfigureClientTracker.cs
@@ -1,0 +1,21 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+	public class ConfigureClientTracker
+	{
+		public bool WasCalled { get; set; }
+	}
+}

--- a/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/InjectedClient.cs
+++ b/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/InjectedClient.cs
@@ -1,0 +1,65 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Transmitly;
+using Transmitly.Delivery;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+	public partial class TransmitlyDependencyInjectionExtensionsTests
+	{
+		class InjectedClient : ICommunicationsClient
+		{
+			private readonly Lazy<ICommunicationsClient> _lazy;
+
+			public InjectedClient(ICommunicationsClientConfigurator configurator)
+			{
+				_lazy = new Lazy<ICommunicationsClient>(() =>
+				{
+					var cfg = new CommunicationsClientBuilder();
+					configurator.ConfigureClient(cfg);
+					return cfg.BuildClient();
+				});
+			}
+
+			public ICommunicationsClient Client
+			{
+				get
+				{
+					return _lazy.Value;
+				}
+			}
+			public void DeliverReport(DeliveryReport report)
+			{
+				Client.DeliverReport(report);
+			}
+
+			public void DeliverReports(IReadOnlyCollection<DeliveryReport> reports)
+			{
+				Client.DeliverReports(reports);
+			}
+
+			public Task<IDispatchCommunicationResult> DispatchAsync(string pipelineName, IReadOnlyCollection<IPlatformIdentityProfile> platformIdentities, ITransactionModel transactionalModel, IReadOnlyCollection<string> channelPreferences, string? cultureInfo = null, CancellationToken cancellationToken = default)
+			{
+				return Client.DispatchAsync(pipelineName, platformIdentities, transactionalModel, channelPreferences, cultureInfo, cancellationToken);
+			}
+
+			public Task<IDispatchCommunicationResult> DispatchAsync(string pipelineName, IReadOnlyCollection<IPlatformIdentityReference> identityReferences, ITransactionModel transactionalModel, IReadOnlyCollection<string> channelPreferences, string? cultureInfo = null, CancellationToken cancellationToken = default)
+			{
+				return Client.DispatchAsync(pipelineName, identityReferences, transactionalModel, channelPreferences, cultureInfo, cancellationToken);
+			}
+		}
+
+	}
+}

--- a/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/MockClientConfigurator.cs
+++ b/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/MockClientConfigurator.cs
@@ -1,0 +1,33 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Transmitly;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+	class MockClientConfigurator : ICommunicationsClientConfigurator
+	{
+		private readonly ConfigureClientTracker _tracker;
+
+		public MockClientConfigurator(ConfigureClientTracker tracker)
+		{
+			_tracker = tracker;
+		}
+
+		public void ConfigureClient(CommunicationsClientBuilder builder)
+		{
+			_tracker.WasCalled = true;
+		}
+	}
+}

--- a/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/TransmitlyDependencyInjectionExtensionsTests.cs
+++ b/tests/Transmitly.Microsoft.Extensions.DependencyInjection.Tests/TransmitlyDependencyInjectionExtensionsTests.cs
@@ -1,0 +1,152 @@
+﻿// ﻿﻿Copyright (c) Code Impressions, LLC. All Rights Reserved.
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License")
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Moq;
+using Transmitly;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+	[TestClass()]
+	public partial class TransmitlyDependencyInjectionExtensionsTests
+	{
+		[TestMethod]
+		public void AddTransmitlyShouldCallConfigureClientOnResolution()
+		{
+			var services = new ServiceCollection();
+			var tracker = new ConfigureClientTracker();
+
+			services.AddSingleton(tracker);
+			services.AddTransmitly(typeof(MockClientConfigurator));
+
+			var provider = services.BuildServiceProvider();
+
+			var client = provider.GetRequiredService<ICommunicationsClient>();
+			client.DeliverReports([]);
+
+			Assert.IsTrue(tracker.WasCalled, "ConfigureClient was not called on MockClientConfigurator.");
+		}
+
+		[TestMethod]
+		public void AddTransmitlyShouldCallConfigureClientOnResolution2()
+		{
+			// Arrange
+			var services = new ServiceCollection();
+			var configuratorMock = new Mock<ICommunicationsClientConfigurator>();
+			configuratorMock
+			.Setup(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()))
+			.Verifiable();
+
+			services.AddSingleton(configuratorMock.Object);
+			services.AddTransmitly<ICommunicationsClientConfigurator>();
+
+			var provider = services.BuildServiceProvider();
+
+			var client = provider.GetRequiredService<ICommunicationsClient>();
+			client.DeliverReports([]);
+			// Assert - Verify ConfigureClient was called exactly once
+			configuratorMock.Verify(c => c.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()), Times.Once);
+		}
+
+		[TestMethod]
+		public void AddTransmitlyGenericShouldCallConfigureClientOnResolution()
+		{
+			var services = new ServiceCollection();
+			var tracker = new ConfigureClientTracker();
+
+			services.AddSingleton(tracker);
+			services.AddTransmitly<MockClientConfigurator>();
+
+			var provider = services.BuildServiceProvider();
+
+			// Act - Trigger service resolution
+			var client = provider.GetRequiredService<ICommunicationsClient>();
+			client.DeliverReports([]);
+			// Assert - Ensure ConfigureClient was called
+			Assert.IsTrue(tracker.WasCalled, "ConfigureClient was not called on MockClientConfigurator.");
+		}
+
+		[TestMethod]
+		public async Task InjectedClientShouldBeRegisteredAsync()
+		{
+			var configuratorMock = new Mock<ICommunicationsClientConfigurator>();
+			configuratorMock.Setup(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>())).Verifiable();
+
+			var services = new ServiceCollection();
+			services.AddSingleton(configuratorMock.Object);
+			services.AddTransmitly<ICommunicationsClientConfigurator, InjectedClient>();
+			//services.AddSingleton(configuratorMock.Object);
+
+			var provider = services.BuildServiceProvider();
+			var client = provider.GetService<ICommunicationsClient>();
+
+			Assert.IsNotNull(client);
+			Assert.IsInstanceOfType<InjectedClient>(client);
+
+		}
+
+		[TestMethod]
+		public async Task InjectedClientShouldNotCallConfigureClientMultipleTimes()
+		{
+
+			var configuratorMock = new Mock<ICommunicationsClientConfigurator>();
+			configuratorMock
+			.Setup(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()))
+			.Callback<CommunicationsClientBuilder>(builder =>
+			{
+				builder.AddPipeline("testPipeline", pipeline => { });
+			})
+			.Verifiable();
+
+			var services = new ServiceCollection();
+			services.AddSingleton(configuratorMock.Object);
+			services.AddTransmitly<ICommunicationsClientConfigurator, InjectedClient>();
+			//services.AddSingleton(configuratorMock.Object);
+
+			var provider = services.BuildServiceProvider();
+			var client = provider.GetRequiredService<ICommunicationsClient>();
+
+			await client.DispatchAsync("testPipeline", new List<IPlatformIdentityProfile>(), TransactionModel.Create(new { }), new List<string>());
+			await client.DispatchAsync("testPipeline", new List<IPlatformIdentityProfile>(), TransactionModel.Create(new { }), new List<string>());
+
+			configuratorMock.Verify(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()), Times.Once);
+		}
+
+		[TestMethod]
+		public async Task DefaultClientShouldNotCallConfigureClientMultipleTimes()
+		{
+
+			var configuratorMock = new Mock<ICommunicationsClientConfigurator>();
+			configuratorMock
+			.Setup(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()))
+			.Callback<CommunicationsClientBuilder>(builder =>
+			{
+				builder.AddPipeline("testPipeline", pipeline => { });
+			})
+			.Verifiable();
+
+			var services = new ServiceCollection();
+			services.AddSingleton(configuratorMock.Object);
+			services.AddTransmitly<ICommunicationsClientConfigurator>();
+			//services.AddSingleton(configuratorMock.Object);
+
+			var provider = services.BuildServiceProvider();
+			var client = provider.GetRequiredService<ICommunicationsClient>();
+
+			await client.DispatchAsync("testPipeline", new List<IPlatformIdentityProfile>(), TransactionModel.Create(new { }), new List<string>());
+			await client.DispatchAsync("testPipeline", new List<IPlatformIdentityProfile>(), TransactionModel.Create(new { }), new List<string>());
+
+			configuratorMock.Verify(x => x.ConfigureClient(It.IsAny<CommunicationsClientBuilder>()), Times.Once);
+		}
+	}
+}


### PR DESCRIPTION
Adds the ability to register transmitly using a custom communications builder configurator. 
Also allows you to to register a configurator with a custom communications client